### PR TITLE
Updating reference scans to a two-volume 1913 edition.

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -51,8 +51,8 @@
 		</meta>
 		<dc:language>en-US</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/3177</dc:source>
-		<dc:source>https://archive.org/details/in.ernet.dli.2015.261235</dc:source>
-		<dc:source>https://archive.org/details/in.ernet.dli.2015.261236</dc:source>
+		<dc:source>https://archive.org/details/acv6910.0001.001.umich.edu</dc:source>
+		<dc:source>https://archive.org/details/acv6910.0001.002.umich.edu</dc:source>
 		<meta property="se:word-count">165627</meta>
 		<meta property="se:reading-ease.flesch">64.54</meta>
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Roughing_It</meta>


### PR DESCRIPTION
This pull request once again updates the "Roughing It" reference scans, this time to a two-volume edition of the book released in 1913. At a glance, the edition appears to be very similar to the previous 1899 edition but includes more modern spellings and simple corrections. This would close #7.